### PR TITLE
Remove cl dependency

### DIFF
--- a/tabby.el
+++ b/tabby.el
@@ -5,6 +5,7 @@
 (require 'json)
 (require 'cl)
 (require 's)
+(require 'dash)
 
 (defgroup tabby nil
   "Tabby."

--- a/tabby.el
+++ b/tabby.el
@@ -3,7 +3,7 @@
 ;;; commentary:
 ;;; code
 (require 'json)
-(require 'cl)
+(require 'cl-lib)
 (require 's)
 (require 'dash)
 


### PR DESCRIPTION
Based on #1
Using obsolete cl package is a bad practice in emacs lisp community. This PR fix it.

@alan-w-255 I can also fix bytecompiler warnings, should I?