### PR TITLE
fix: post the `dismiss` event to server

### DIFF
--- a/tabby.el
+++ b/tabby.el
@@ -1,7 +1,7 @@
 ;;; tabby.el --- An unofficial tabby plugin for Emacs  -*- lexical-binding:t -*-
 
 ;; Author: Alan Wong <heywym@qq.com>
-;; Version: 0.1.0
+;; Version: 0.1.1
 ;; Package-Requires: ((emacs "27.2") (s "1.12.0"))
 ;; Keywords: tabby, completion, llm, copilot
 ;; URL: http://github.com/alan-w-255/tabby.el

--- a/tabby.el
+++ b/tabby.el
@@ -384,8 +384,21 @@ Use this for custom bindings in `tabby-mode'.")
 (defun tabby-dismiss ()
   "Dismiss completion."
   (interactive)
-  (setq tabby--current-completion-request nil)
-  (tabby--clear-overlay))
+  (when tabby--current-completion-request
+    (setq tabby--current-completion-request nil)
+    (tabby--clear-overlay)
+    (when-let* ((response tabby--current-completion-response)
+                (completion-id (cadr response))
+                (choices (plist-get (cadr response) :choices))
+                (choice (car choices)))
+      (setq tabby--current-completion-response nil)
+      (tabby--agent-post-event
+       `(:type
+         "dismiss"
+         :completion_id
+         ,completion-id
+         :choice_index
+         ,(plist-get choice :index))))))
 
 (defmacro tabby--satisfy-predicates (enable disable)
   "Return t if satisfy all predicates in ENABLE and none in DISABLE."


### PR DESCRIPTION
Fixed the delay in autocomplete caused by not sending a `dismiss` event to the server.