### PR TITLE
fix: rename string-split to split-string

### DIFF
--- a/tabby.el
+++ b/tabby.el
@@ -194,7 +194,7 @@ Use this for custom bindings in `tabby-mode'.")
   `(:user
     (:emacs (:triggerMode ,tabby-trigger-mode))
     :session
-    (:client ,(car (string-split (emacs-version) "\n"))
+    (:client ,(car (split-string (emacs-version) "\n"))
              :ide (:name "Emacs" :version ,(car (split-string emacs-version "\n")))
              :tabby_plugin (:name "TabbyML/emacs-tabby" :version ,tabby-version))))
 


### PR DESCRIPTION
Got the following error when using `tabby-mode` in previous commit:
 
```
Symbol's function definition is void: string-split
```

This fix will allow to run `tabby-mode` in vanilla emacs. I didn't get this error when using `doom-emacs`.